### PR TITLE
Remove deprecation warning in spec test

### DIFF
--- a/spec/support/action_mailer.rb
+++ b/spec/support/action_mailer.rb
@@ -1,7 +1,8 @@
+deliver_method = ActionMailer.respond_to?(:version) && ActionMailer.version.to_s.to_f >= 4.2 ? :deliver_now! : :deliver!
 shared_examples "with header" do |header, value|
   it "sets header #{header}" do
     expect {
-      subject.deliver!
+      subject.__send__(deliver_method)
     }.to change { ActionMailer::Base.deliveries.count }.by(1)
     m = ActionMailer::Base.deliveries.last
     expect(m.header.to_s).to match(/(\r\n)?#{header}: #{value}(\r\n)?/)
@@ -10,7 +11,7 @@ end
 shared_examples "without header" do |header|
   it "does not set header #{header}" do
     expect {
-      subject.deliver!
+      subject.__send__(deliver_method)
     }.to change { ActionMailer::Base.deliveries.count }.by(1)
     m = ActionMailer::Base.deliveries.last
     expect(m.header.to_s).not_to match(/(\r\n)?#{header}: [^\r]*(\r\n)?/)
@@ -20,7 +21,7 @@ shared_examples "raise an exception" do |exception|
   it "raises #{exception}" do
     expect {
       expect {
-        subject.deliver!
+        subject.__send__(deliver_method)
       }.to raise_error(exception)
     }.to change { ActionMailer::Base.deliveries.count }.by(0)
   end


### PR DESCRIPTION
Remove the warning `DEPRECATION WARNING:`#deliver!`is deprecated and will be removed in Rails 5. Use`#deliver_now!`to deliver immediately or`#deliver_later!`to deliver through Active Job. (called from block (3 levels) in <top (required)> at /Users/dtaniwaki/github/mandriller/spec/support/action_mailer.rb:4)` in the spec test.
