### PR TITLE
Drop deprecated Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 
 rvm:
-  - 2.2
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
 
 install:
   - "gem install bundler"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: ruby
 
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1
   - 2.2
 
 install:

--- a/mandriller.gemspec
+++ b/mandriller.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
+  gem.required_ruby_version = ['>= 2.2', '< 2.5']
+
   gem.add_dependency "actionmailer", ">= 3.0"
   gem.add_dependency "multi_json"
 


### PR DESCRIPTION
Ruby older than 2.1 has been deprecated.

https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/